### PR TITLE
Wagtail 64 upgrade

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,17 +3,17 @@ default_language_version:
   python: python3.12
 repos:
   - repo: https://github.com/python/black
-    rev: 23.1.0
+    rev: 25.1.0
     hooks:
       - id: black
         exclude: migrations/
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8
     # flake8 config is in setup.cfg
-    rev: 3.8.3
+    rev: 7.1.2
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+- Tox testing add python 3.13, drop 3.8
+- Tox testing add Wagtail 6.3 and 6.4 and Django 5.1
+- Tox testing drop Wagtail 6.0 & Django 3.2
+- Classifiers drop Django 3.2
+- Classifiers add Django 5.1
+- Add development_testing dependencies
+
 ## 1.1.0 (2024-03-11)
 
 - Add tests for Wagtail 5.1+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,7 +15,7 @@ git clone https://github.com/torchbox/wagtail-makeup
 ```bash
 python3 -m venv venv
 source venv/bin/activate
-pip install -e ".[testing]"
+pip install -e ".[testing,development]"
 ```
 
 ### Pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,13 @@ license_files =
   LICENSE.txt
 
 [options]
-python_requires = >= 3.8
+python_requires = >= 3.9
 setup_requires =
   setuptools >= 40.6
   pip >= 10
 include_package_data = true
 packages = find:
 install_requires =
-    Django>=3.2
+    Django>=4.2
     wagtail>=5.2
     python-unsplash>=1.1.0, <1.2

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,12 @@ testing_extras = [
     "coverage>=4.5",
 ]
 
+development_extras = [
+    "black==25.1.0",
+    "flake8==7.1.2",
+    "isort==6.0.1",
+]
+
 setup(
     name="wagtailmakeup",
     version="1.1.0",
@@ -28,14 +34,17 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     install_requires=["wagtail>=5.2", "python-unsplash>=1.1.0"],
-    extras_require={"testing": testing_extras},
+    extras_require={
+        "testing": testing_extras,
+        "development": development_extras,
+    },
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,30 @@
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 DJANGO =
-    3.2: dj32
     4.2: dj42
     5.0: dj50
+    5.1: dj51
 
 WAGTAIL =
     5.2: wt52
-    6.0: wt60
+    6.3: wt63
+    6.4: wt64
 
 [tox]
 skipsdist = True
 usedevelop = True
 
 envlist =
-    py{38,39,310}-dj32-wt52
-    py{38,39,310,311}-dj42-wt{52,60}
-    py{311,312}-dj50-wt{52,60}
+    py{39,310,311,312}-dj{42}-wt{52,63,64}
+    py{310,311,312}-dj{50,51}-wt{52,63,64}
+    py313-dj{51}-wt{63,64}
 
 [testenv]
 description = Unit tests
@@ -31,15 +32,16 @@ install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands = coverage run --source=wagtailmakeup runtests.py
 
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 
 deps =
-    dj32: Django>=3.2,<4.0
     dj42: Django>=4.2,<4.3
     dj50: Django>=5.0,<5.1
+    dj51: Django>=5.1,<5.2
     wt52: wagtail>=5.2,<5.3
-    wt60: wagtail>=6.0,<6.1
+    wt63: wagtail>=6.3,<6.4
+    wt64: wagtail>=6.4,<6.5

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    py{39,310,311,312}-dj{42}-wt{52,63,64}
-    py{310,311,312}-dj{50,51}-wt{52,63,64}
-    py313-dj{51}-wt{63,64}
+    py{39,310,311}-dj42-wt{52,63,64}
+    py{310,311,312}-dj50-wt{52,63,64}
+    py{312,313}-dj51-wt{63,64}
 
 [testenv]
 description = Unit tests


### PR DESCRIPTION
This pull request includes several updates to dependencies and configurations, as well as improvements to the development and testing setup.

Dependency updates:

* [x] Updated `black` to version 25.1.0, `isort` to version 6.0.1, and `flake8` to version 7.1.2.

Development and testing setup:

* [x] Added a new `development_extras` list with `black`, `flake8`, and `isort` dependencies, and modified `extras_require` to include `development`. 
* [x] Added support for Python 3.13 and Django 5.1, and updated Wagtail versions to include 6.3 and 6.4. Removed support for Python 3.8, Django 3.2, and Wagtail 6.0.

Documentation updates:

* [x] Updated the pip install command to include the `development` extras.
* [x] Changelog updated

Actions updates:
* [x] Remove python 3.8 and add python 3.13