### PR TITLE
Wagtail 7.2 maintenance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 default_language_version:
   node: system
-  python: python3.12
+  python: python3.14
 repos:
   - repo: https://github.com/python/black
-    rev: 25.1.0
+    rev: 25.11.0
     hooks:
       - id: black
         exclude: migrations/
   - repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
+    rev: 7.0.0
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8
     # flake8 config is in setup.cfg
-    rev: 7.1.2
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+Wagtail 7.2 maintenance
+
+- Tox testing add Wagtail 7.2
+- Classifiers add Wagtail 7.2
+
 Wagtail 7.0 maintenance
 
 - Tox testing add Wagtail 7.0, 7.1 and Django 5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,5 +21,5 @@ include_package_data = true
 packages = find:
 install_requires =
     Django>=4.2
-    wagtail>=5.2
+    wagtail>=6.3
     python-unsplash>=1.1.0, <1.2

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ testing_extras = [
 ]
 
 development_extras = [
-    "black==25.1.0",
-    "flake8==7.1.2",
-    "isort==6.0.1",
+    "black==25.11.0",
+    "flake8==7.3.0",
+    "isort==7.0.0",
 ]
 
 setup(
@@ -33,7 +33,7 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    install_requires=["wagtail>=5.2", "python-unsplash>=1.1.0"],
+    install_requires=["wagtail>=6.3", "python-unsplash>=1.1.0"],
     extras_require={
         "testing": testing_extras,
         "development": development_extras,
@@ -46,7 +46,6 @@ setup(
         "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",
         "Framework :: Wagtail :: 7",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [gh-actions:env]
 DJANGO =
@@ -13,19 +13,18 @@ DJANGO =
     5.2: dj52
 
 WAGTAIL =
-    5.2: wt52
     6.3: wt63
-    6.4: wt64
     7.0: wt70
-    7.1: wt71
+    7.2: wt72
 
 [tox]
 skipsdist = True
 usedevelop = True
 
 envlist =
-    py{39,310,311,312}-dj42-wt{52,63,64,70,71}
-    py{310,311,312,313}-dj{51,52}-wt{63,64,70,71}
+    py{310,311,312}-dj42-wt{63,70,72}
+    py{310,311,312,313}-dj{51,52}-wt{63,70,72}
+    py314-dj52-wt72
 
 [testenv]
 description = Unit tests
@@ -33,18 +32,16 @@ install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands = coverage run --source=wagtailmakeup runtests.py
 
 basepython =
-    py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
     py313: python3.13
+    py314: python3.14
 
 deps =
     dj42: Django>=4.2,<4.3
     dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<5.3
-    wt52: wagtail>=5.2,<5.3
     wt63: wagtail>=6.3,<6.4
-    wt64: wagtail>=6.4,<6.5
     wt70: wagtail>=7.0,<7.1
-    wt71: wagtail>=7.1,<7.2
+    wt72: wagtail>=7.2,<7.3


### PR DESCRIPTION
This pull request updates the project's Python and Wagtail version support.

**Python and Wagtail version support:**

* Added support for Python 3.14 in the test matrix (`.github/workflows/tests.yml`, `tox.ini`) and set it as the default language version for pre-commit hooks (`.pre-commit-config.yaml`). 
* Updated minimum required Wagtail version to 6.3 in `setup.cfg` and `setup.py`, and added support for Wagtail 7.2

**Development and testing dependencies:**

* Upgraded development dependencies: `black` to 25.11.0, `flake8` to 7.3.0, and `isort` to 7.0.0 in both `setup.py` and `.pre-commit-config.yaml`. 

**Documentation and changelog:**

* Updated `CHANGELOG.md` to document the addition of Wagtail 7.2 support in tox testing and classifiers.